### PR TITLE
Changed a word in retry warning pop up

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -108,7 +108,7 @@
         "name": "retryDialogBodyText",
         "label": "Retry dialog body text",
         "type": "text",
-        "default": "By pressing \"Retry\" you will loose your current recording."
+        "default": "By pressing \"Retry\" you will lose your current recording."
       },
       {
         "name": "retryDialogConfirmText",


### PR DESCRIPTION
The warning pop-up for retrying should be "By pressing "Retry" you will lose..."  instead of "By pressing "Retry" you will loose...". This was reported [here](https://h5p.org/comment/24977#comment-24977).